### PR TITLE
fix: ODN_rename_user_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## v0.2.0 (2024-02-02)
+## v0.2.1 (2024-12-10)
+
+### Changes:
+
+- Rename `user` to `usr` for `current_user` Proc ([`f4de214`](https://github.com/buyco/datadog-json-logger/commit/f4de2145cfe3f730c1d50e8bee29c806cc9979d7)) (by Eth3rnit3)
+
+## v0.2.0 (2024-12-10)
 
 ### New feature:
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    datadog-json_logger (0.2.0)
+    datadog-json_logger (0.2.1)
       ddtrace (>= 1.16)
 
 GEM

--- a/lib/datadog/loggers/version.rb
+++ b/lib/datadog/loggers/version.rb
@@ -2,6 +2,6 @@
 
 module Datadog
   module Loggers
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/lib/datadog/rack_middleware.rb
+++ b/lib/datadog/rack_middleware.rb
@@ -109,7 +109,7 @@ module Datadog
       return {} unless config.log_current_user?
 
       {
-        user: config.current_user.call(env)
+        usr: config.current_user.call(env)
       }
     end
   end

--- a/spec/datadog/rack_middleware_spec.rb
+++ b/spec/datadog/rack_middleware_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Datadog::RackMiddleware do
 
         it "logs the current user" do
           middleware.call(env)
-          expect(logger).to have_received(:info).with(hash_including(user: current_user))
+          expect(logger).to have_received(:info).with(hash_including(usr: current_user))
         end
       end
 
@@ -141,7 +141,7 @@ RSpec.describe Datadog::RackMiddleware do
 
         it "logs the current user" do
           middleware.call(env)
-          expect(logger).to have_received(:info).with(hash_including(user: user))
+          expect(logger).to have_received(:info).with(hash_including(usr: user))
         end
       end
 
@@ -155,7 +155,26 @@ RSpec.describe Datadog::RackMiddleware do
 
         it "does not log the current user" do
           middleware.call(env)
-          expect(logger).to have_received(:info).with(including(:user))
+          expect(logger).to have_received(:info).with(including(:usr))
+        end
+      end
+
+      context "when custom_context is set with usr key" do
+        let(:current_user) do
+          ->(_env) { { id: 1, email: "current_user@from_env.com" } }
+        end
+        let(:custom_context) do
+          -> { { usr: { id: 2, email: "current_user@from_context.com" } } }
+        end
+
+        before do
+          allow(logger.config).to receive(:custom_context).and_return(custom_context)
+          allow(logger.config).to receive(:current_user).and_return(current_user)
+        end
+
+        it "logs the current user" do
+          middleware.call(env)
+          expect(logger).to have_received(:info).with(hash_including(usr: current_user.call(env)))
         end
       end
     end
@@ -168,7 +187,7 @@ RSpec.describe Datadog::RackMiddleware do
 
       it "does not log the current user" do
         middleware.call(env)
-        expect(logger).to have_received(:info).with(hash_not_including(:user))
+        expect(logger).to have_received(:info).with(hash_not_including(:usr))
       end
     end
   end


### PR DESCRIPTION
Use datador reserved attributes for better user logging
https://docs.datadoghq.com/fr/standard-attributes/

![Capture d’écran 2024-12-10 à 15 47 09](https://github.com/user-attachments/assets/1afeef98-3b70-48db-9058-553d41b7aa5a)
